### PR TITLE
Extract the data structure Trie

### DIFF
--- a/FRDIntent.xcodeproj/project.pbxproj
+++ b/FRDIntent.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		A382FE421D951C96007099DE /* FRDRouteParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A382FE411D951C96007099DE /* FRDRouteParameters.swift */; };
 		A384541D1DA807B100835B70 /* FRDIntentRegisters.plist in Resources */ = {isa = PBXBuildFile; fileRef = A384541C1DA807B100835B70 /* FRDIntentRegisters.plist */; };
 		A3EBF8B31DB35D0100C7ED83 /* FRDURLRoutesRegisters.plist in Resources */ = {isa = PBXBuildFile; fileRef = A3EBF8B21DB35D0100C7ED83 /* FRDURLRoutesRegisters.plist */; };
+		A3FE9EE31DF656B6006038DB /* Trie.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FE9EE21DF656B6006038DB /* Trie.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -103,6 +104,7 @@
 		A382FE411D951C96007099DE /* FRDRouteParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FRDRouteParameters.swift; sourceTree = "<group>"; };
 		A384541C1DA807B100835B70 /* FRDIntentRegisters.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = FRDIntentRegisters.plist; sourceTree = "<group>"; };
 		A3EBF8B21DB35D0100C7ED83 /* FRDURLRoutesRegisters.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = FRDURLRoutesRegisters.plist; sourceTree = "<group>"; };
+		A3FE9EE21DF656B6006038DB /* Trie.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Trie.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -196,6 +198,7 @@
 			children = (
 				A354CC6D1D7560EC00830990 /* RouteManager.swift */,
 				A382FE411D951C96007099DE /* FRDRouteParameters.swift */,
+				A3FE9EE21DF656B6006038DB /* Trie.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -390,6 +393,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A3FE9EE31DF656B6006038DB /* Trie.swift in Sources */,
 				A354CC801D75B8C200830990 /* IntentForResult.swift in Sources */,
 				A354CC7E1D75B8C200830990 /* FRDControllerManager.swift in Sources */,
 				A354CC831D75B8C200830990 /* FRDPushDisplay.swift in Sources */,

--- a/FRDIntent/Source/Core/FRDRouteParameters.swift
+++ b/FRDIntent/Source/Core/FRDRouteParameters.swift
@@ -15,7 +15,6 @@ import Foundation
 public class FRDRouteParameters: NSObject {
 
   /// The key to get the url from parameters of block handler.
-
   public static let URLRouteURL = "URLRouteURL"
 
 }

--- a/FRDIntent/Source/Core/RouteManager.swift
+++ b/FRDIntent/Source/Core/RouteManager.swift
@@ -10,25 +10,6 @@ import Foundation
 
 /**
  RouteManager offer the public operation interface of route path search tree.
-
- For example, If we register three urls into the search tree:
- 
- /user/:userId/profile
- /story/:storyId
- /subject/:subjectId
-
- We will find that the tree will be like this:
-
-             "/"
-         /    |      \
-    "user" "story" "subject"
-       /      |        \
-  ":userId" ":storId" ":subjectId"
-     /
- "profile"
-
- Every node have two values: clazz and handler.
-
  */
 class RouteManager {
 
@@ -38,112 +19,88 @@ class RouteManager {
 
   typealias RoutePathNodeValueType = (FRDIntentReceivable.Type?, URLRoutesHandler?)
 
-  fileprivate var routes = RoutePathNode<RoutePathNodeValueType>(path: "/")
+  fileprivate var routes = Trie<RoutePathNodeValueType>()
+
+  // MARK: - Register
 
   /**
-   Regiser url for save the value in the route path search tree.
+   Regiser url for save the clazz in the routes.
    
    - parameter url: The path for search the storage position.
-   - parameter value: The value to be saved.
+   - parameter clazz: The clazz to be saved.
    */
   func register(url: URL, clazz: FRDIntentReceivable.Type) -> Bool {
 
-    guard let paths = url.pathComponentsWithoutSlash else {
-      return false
-    }
-
-    let (_, node) = routes.search(paths: paths)
-    if node.path == paths.last {
-      // find it, update
-      let handler: URLRoutesHandler?
-      if let (_, oldHandler) = node.value {
-        handler =  oldHandler
-      } else {
-        handler = nil
-      }
-      node.value = (clazz, handler)
-
-
+    if let (_, handler) = routes.search(url: url) {
+      routes.insert(url: url, value: (clazz, handler))
     } else {
       // not find it, insert
-      let _ = routes.insert(paths: paths, value: (clazz, nil))
+      routes.insert(url: url, value: (clazz, nil))
     }
 
     return true
-  }
-
-  func register(url: URL, handler: @escaping ([String: AnyObject]) -> ()) -> Bool {
-
-    guard let paths = url.pathComponentsWithoutSlash else {
-      return false
-    }
-
-    let (_, node) = routes.search(paths: paths)
-    if node.path == paths.last {
-      // find it, update
-      let clazz: FRDIntentReceivable.Type?
-      if let (oldClazz, _) = node.value {
-        clazz =  oldClazz
-      } else {
-        clazz = nil
-      }
-      node.value = (clazz, handler)
-
-    } else {
-      // not find it, insert
-      let node = routes.insert(paths: paths, value: (nil, handler))
-      guard let _ = node else {
-        return false
-      }
-    }
-
-    return true
-
   }
 
   /**
-   Search the value in in the route path search tree whith the url.
+   Regiser url for save the handler in the routes.
 
    - parameter url: The path for search the storage position.
-   - returns: A tuple with parameters and value in the node searched.
+   - parameter hanlder: The handler to be saved.
+  */
+  func register(url: URL, handler: @escaping ([String: AnyObject]) -> ()) -> Bool {
+
+    if let (clazz, _) = routes.search(url: url) {
+      routes.insert(url: url, value: (clazz, handler))
+    } else {
+      // not find it, insert
+      routes.insert(url: url, value: (nil, handler))
+    }
+
+    return true
+  }
+
+  // MARK: - Search
+
+  /**
+   Search the controller in in the routes whith the url.
+
+   - parameter url: The url for search the clazz.
+
+   - returns: A tuple with parameters and clazz.
    */
   func searchController(url: URL) -> ([String: AnyObject], FRDIntentReceivable.Type?) {
-    let (params, value) = search(url: url)
+    let params = extractParameters(url: url)
 
-    if let (clazz, _) = value {
+    if let (clazz, _) = routes.searchWithNearestMatch(url: url) {
       return (params, clazz)
     } else {
       return (params, nil)
     }
+
   }
 
+  /**
+   Search the handler in in the route whith the url.
 
+   - parameter url: The url for search the handler.
+
+   - returns: A tuple with parameters and handler.
+   */
   func searchHandler(url: URL) -> ([String: AnyObject], (([String: AnyObject]) -> ())?) {
-    let (params, value) = search(url: url)
+    let params = extractParameters(url: url)
 
-    if let (_, handler) = value {
+    if let (_, handler) = routes.searchWithNearestMatch(url: url) {
       return (params, handler)
     } else {
       return (params, nil)
     }
   }
 
-  private func search(url: URL) -> ([String: AnyObject], RoutePathNodeValueType?) {
+  // MARK: - Private Methods
+  private func extractParameters(url: URL) -> [String: AnyObject] {
 
-    guard let paths = url.pathComponentsWithoutSlash else {
-      return ([String: AnyObject](), nil)
-    }
-
-    var (params, node) = routes.search(paths: paths)
-
-    decorate(params: &params, url: url)
-
-    params.updateValue(url as AnyObject, forKey: FRDRouteParameters.URLRouteURL)
-
-    return (params, node.value)
-  }
-
-  private func decorate(params: inout [String: AnyObject], url: URL) {
+    // Extract placeholder parameters
+    var params: [String: AnyObject] = routes.matchUrlPattern(url: url)
 
     // Add url to params
     params.updateValue(url as AnyObject, forKey: FRDRouteParameters.URLRouteURL)
@@ -161,162 +118,8 @@ class RouteManager {
     if let fragment = url.fragment {
       params.updateValue(fragment as AnyObject, forKey: "fragment")
     }
-  }
 
-}
-
-
-// MARK: Private Data Structure
-
-/**
- RoutePathNode is the data structure presenting a route path search tree node.
- */
-private class RoutePathNode<T> {
-
-  var path: String
-
-  var value: T?
-
-  var children: [String: RoutePathNode<T>]?
-
-  init(path: String, value: T?, children: [String: RoutePathNode]?) {
-    self.path = path
-    self.value = value
-    self.children = children
-  }
-
-  convenience init(path: String) {
-    self.init(path: path, value: nil, children: nil)
-  }
-
-  convenience init(path: String, value: T) {
-    self.init(path: path, value: value, children: nil)
-  }
-
-
-  var isPlaceHolder: Bool {
-    return path.hasPrefix(":")
-  }
-
-  var placeHolderName: String? {
-    if isPlaceHolder {
-      let index = path.characters.index(path.startIndex, offsetBy: 1)
-      return path.substring(from: index)
-    }
-    return nil
-  }
-
-  var placeHolderChild: RoutePathNode? {
-
-    guard let children = children else {
-      return nil
-    }
-
-    for (_, node) in children {
-      if node.isPlaceHolder {
-        return node
-      }
-    }
-
-    return nil
-  }
-
-  func add(childNode node: RoutePathNode) {
-    if let _ = children {
-      children?[node.path] = node
-    } else {
-      children = [String: RoutePathNode]()
-      children?[node.path] = node
-    }
-  }
-
-  func contain(childNodePath: String) -> Bool {
-    if let children = children {
-      return children[childNodePath] != nil
-    }
-    return false
-  }
-
-  var description: String {
-    return "path:\(self.path), value:\(self.value), children:\(self.children)"
-  }
-
-}
-
-// MARK: Operations of Route Path Search Tree
-
-extension RoutePathNode {
-
-  func insert(paths: [String], value: T) -> RoutePathNode? {
-
-    var node = self
-    for path in paths {
-
-      let childNode: RoutePathNode
-      if node.contain(childNodePath: path) {
-        childNode = node.children![path]!
-      } else {
-        childNode = RoutePathNode(path: path, value: value)
-        node.add(childNode: childNode)
-      }
-
-      node = childNode
-
-    }
-
-    node.value = value
-    return node
-
-  }
-
-  func search(paths: [String]) -> ([String: AnyObject], RoutePathNode) {
-
-    var params = [String: AnyObject]()
-
-    var node = self
-    for path in paths {
-
-      if node.contain(childNodePath: path) {
-        node = node.children![path]!
-
-      } else if let placeHolderChild = node.placeHolderChild {
-
-        let placeHolderName = placeHolderChild.placeHolderName!
-        params[placeHolderName] = path as AnyObject?
-        node = placeHolderChild
-      }
-      
-    }
-
-    return (params, node)
-  }
-
-}
-
-
-// MARK: Private Helper Methods
-
-private extension Array where Element: Equatable {
-
-  mutating func remove(object: Element) {
-    if let index = self.index(of: object) {
-      self.remove(at: index)
-    }
-  }
-
-}
-
-private extension URL {
-
-  var pathComponentsWithoutSlash: [String]? {
-
-    var array = pathComponents
-    array.remove(object: "/")
-    return array
-  }
-
-  var queryItems: [URLQueryItem]? {
-    return URLComponents(url: self, resolvingAgainstBaseURL: false)?.queryItems
+    return params
   }
 
 }

--- a/FRDIntent/Source/Core/Trie.swift
+++ b/FRDIntent/Source/Core/Trie.swift
@@ -1,0 +1,245 @@
+//
+//  Trie.swift
+//  FRDIntent
+//
+//  Created by GUO Lin on 06/12/2016.
+//  Copyright © 2016 Douban Inc. All rights reserved.
+//
+
+import Foundation
+
+/**
+ The trie data structure for storing and search with url.
+
+ Insert these three urls in an empty trie:
+ 
+ ```
+ /user/:userId/profile
+ /story/:storyId
+ /subject/:subjectId
+ ```
+ 
+ We will get a trie like this:
+ 
+ ```
+             ""
+         /    |     \
+    "user" "story" "subject"
+      /       |        \
+  ":userId" ":storId" ":subjectId"
+    /
+ "profile"
+ ```
+
+ This trie supports url pattern match with prefix ":".
+
+*/
+class Trie<T> {
+
+  private var root: TrieNode<T>
+
+  init() {
+    root = TrieNode<T>(key: "")
+  }
+
+  /**
+   Insert the url into the trie.
+
+   - parameter url: the url.
+   - parameter value: the value for inserting.
+   */
+  func insert(url: URL, value: T) {
+    guard let paths = url.pathComponentsWithoutSlash else {
+      return
+    }
+    insert(paths: paths, value: value)
+  }
+
+  private func insert(paths: [String], value: T) {
+    var currentNode = root
+    for path in paths {
+      if let child = currentNode.children[path] {
+        currentNode = child
+      } else {
+        let newChild = TrieNode<T>(key: path)
+        currentNode.children[path] = newChild
+        currentNode = newChild
+      }
+    }
+    currentNode.value = value
+  }
+
+  /**
+   Search the value with url key.
+   
+   - parameter url: the url.
+
+   - returns: the node's value.
+   */
+  func search(url: URL) -> T? {
+    guard let paths = url.pathComponentsWithoutSlash else {
+      return nil
+    }
+    return search(paths: paths)
+  }
+
+  private func search(paths: [String]) -> T? {
+    var currentNode = root
+    for path in paths {
+      if let child = currentNode.children[path] {
+        currentNode = child
+      } else {
+        if let child = currentNode.childOrFirstPlaceholder(key: path) {
+          currentNode = child
+        } else {
+          return nil
+        }
+      }
+    }
+    return currentNode.value
+  }
+
+  /**
+   This search method's behavior is different with classical trie's search.
+
+   - parameter url: the url.
+
+   - returns: the node's value. If trie has this paths, return the value in this node. If trie has not this paths, return the nearest registered url parent.
+   */
+  func searchWithNearestMatch(url: URL) -> T? {
+    guard let paths = url.pathComponentsWithoutSlash else {
+      return nil
+    }
+    return searchWithNearestMatch(paths: paths)
+  }
+
+  private func searchWithNearestMatch(paths: [String]) -> T? {
+    var currentNode = root
+    var nearestUrlParent = root
+    for path in paths {
+      if let child = currentNode.children[path] {
+        currentNode = child
+        if currentNode.isRegisteredUrl {
+          nearestUrlParent = currentNode
+        }
+      } else {
+        if let child = currentNode.childOrFirstPlaceholder(key: path) {
+          currentNode = child
+          if currentNode.isRegisteredUrl {
+            nearestUrlParent = currentNode
+          }
+        } else {
+          // not find
+          return nearestUrlParent.value
+        }
+      }
+    }
+    return currentNode.value
+  }
+
+  /**
+   This trie support url pattern match. The url with prefix ":" is the url pattern, for example ":userId".
+   This method extract all the patterns in the url.
+   
+   - parameter url: the url for find the pattern match.
+
+   - returns: dictionary for the pattern match result.
+   */
+  func matchUrlPattern(url: URL) -> [String: AnyObject] {
+    guard let paths = url.pathComponentsWithoutSlash else {
+      return [:]
+    }
+
+    var params: [String: AnyObject] = [:]
+    var currentNode = root
+    for path in paths {
+      if let child = currentNode.children[path] {
+        currentNode = child
+      } else {
+        if let child = currentNode.childOrFirstPlaceholder(key: path) {
+          if child.isPlaceholder {
+            params[child.placeholder!] = path as AnyObject
+          }
+          currentNode = child
+        } else {
+          // not find
+          return params
+        }
+      }
+    }
+    return params
+  }
+}
+
+
+// MARK: - Trie's node data structure: TrieNode
+
+fileprivate class TrieNode<T> {
+
+  var key: String
+  var value: T?
+  var children: [String: TrieNode<T>]
+
+  var isRegisteredUrl: Bool {
+    return value != nil
+  }
+
+  var isPlaceholder: Bool {
+    return key.hasPrefix(":")
+  }
+
+  var placeholder: String? {
+    if isPlaceholder {
+      return key.substring(from: key.index(key.startIndex, offsetBy: 1))
+    }
+    return nil
+  }
+
+  convenience init(key: String) {
+    self.init(key: key, value: nil)
+  }
+
+  init(key: String, value: T?) {
+    self.key = key
+    self.value = value
+    self.children = [:]
+  }
+
+  func childOrFirstPlaceholder(key: String) -> TrieNode? {
+    if let child = children[key] {
+      return child
+    } else {
+      for child in children.values where child.isPlaceholder {
+        return child
+      }
+    }
+    return nil
+  }
+
+  var description: String {
+    return "key:\(self.key), value:\(self.value), children:\(self.children)"
+  }
+}
+
+
+// MARK: - URL extension
+
+extension URL {
+
+  /**
+   The path components without the first slash.
+   
+   - returns: array of path components without slash.
+   */
+  var pathComponentsWithoutSlash: [String]? {
+    var array = pathComponents
+    if let first = array.first, first == "/" {
+      array.removeFirst()
+    }
+    return array
+  }
+
+  var queryItems: [URLQueryItem]? {
+    return URLComponents(url: self, resolvingAgainstBaseURL: false)?.queryItems
+  }
+}

--- a/FRDIntent/Source/URLRoutes/FRDURLRoutes.swift
+++ b/FRDIntent/Source/URLRoutes/FRDURLRoutes.swift
@@ -106,7 +106,7 @@ public extension FRDURLRoutes {
 
 }
 
-private extension UIApplication {
+fileprivate extension UIApplication {
 
   class func topViewController(base: UIViewController? = UIApplication.shared.keyWindow?.rootViewController) -> UIViewController? {
 


### PR DESCRIPTION
查询和存储注册结构的 Path Node Search Tree 实际上就是一个按 url path 构建的 [Trie](https://en.wikipedia.org/wiki/Trie)。

该 PR 做了以下两件事：
- 改进了之前的 Path Node Search Tree 实现，并将其改名 Trie;
- 重新分隔了插入和查询接口 `RouteManager` 和基础数据结构 `Trie` 之间的边界。