### PR TITLE
API: adjust to swift 3 api design guide

### DIFF
--- a/FRDIntent/Source/Core/RouteManager.swift
+++ b/FRDIntent/Source/Core/RouteManager.swift
@@ -29,7 +29,7 @@ class RouteManager {
    - parameter url: The path for search the storage position.
    - parameter clazz: The clazz to be saved.
    */
-  @discardableResult func register(url: URL, clazz: FRDIntentReceivable.Type) -> Bool {
+  @discardableResult func register(_ url: URL, clazz: FRDIntentReceivable.Type) -> Bool {
 
     if let (_, handler) = routes.search(url) {
       routes.insert(url, withValue: (clazz, handler))
@@ -47,7 +47,7 @@ class RouteManager {
    - parameter url: The path for search the storage position.
    - parameter hanlder: The handler to be saved.
   */
-  @discardableResult func register(url: URL, handler: @escaping URLRoutesHandler) -> Bool {
+  @discardableResult func register(_ url: URL, handler: @escaping URLRoutesHandler) -> Bool {
 
     if let (clazz, _) = routes.search(url) {
       routes.insert(url, withValue: (clazz, handler))
@@ -68,8 +68,8 @@ class RouteManager {
 
    - returns: A tuple with parameters and clazz.
    */
-  func searchController(url: URL) -> ([String: AnyObject], FRDIntentReceivable.Type?) {
-    let params = extractParameters(url: url)
+  func searchController(for url: URL) -> ([String: AnyObject], FRDIntentReceivable.Type?) {
+    let params = extractParameters(from: url)
 
     if let (clazz, _) = routes.searchNearestMatchedValue(with: url) {
       return (params, clazz)
@@ -86,8 +86,8 @@ class RouteManager {
 
    - returns: A tuple with parameters and handler.
    */
-  func searchHandler(url: URL) -> ([String: AnyObject], URLRoutesHandler?) {
-    let params = extractParameters(url: url)
+  func searchHandler(for url: URL) -> ([String: AnyObject], URLRoutesHandler?) {
+    let params = extractParameters(from: url)
 
     if let (_, handler) = routes.searchNearestMatchedValue(with: url) {
       return (params, handler)
@@ -97,7 +97,7 @@ class RouteManager {
   }
 
   // MARK: - Private Methods
-  private func extractParameters(url: URL) -> [String: AnyObject] {
+  private func extractParameters(from url: URL) -> [String: AnyObject] {
 
     // Extract placeholder parameters
     var params = routes.matchedPattern(for: url)

--- a/FRDIntent/Source/Core/RouteManager.swift
+++ b/FRDIntent/Source/Core/RouteManager.swift
@@ -31,11 +31,11 @@ class RouteManager {
    */
   @discardableResult func register(url: URL, clazz: FRDIntentReceivable.Type) -> Bool {
 
-    if let (_, handler) = routes.search(url: url) {
-      routes.insert(url: url, value: (clazz, handler))
+    if let (_, handler) = routes.search(url) {
+      routes.insert(url, withValue: (clazz, handler))
     } else {
       // not find it, insert
-      routes.insert(url: url, value: (clazz, nil))
+      routes.insert(url, withValue: (clazz, nil))
     }
 
     return true
@@ -49,11 +49,11 @@ class RouteManager {
   */
   @discardableResult func register(url: URL, handler: @escaping URLRoutesHandler) -> Bool {
 
-    if let (clazz, _) = routes.search(url: url) {
-      routes.insert(url: url, value: (clazz, handler))
+    if let (clazz, _) = routes.search(url) {
+      routes.insert(url, withValue: (clazz, handler))
     } else {
       // not find it, insert
-      routes.insert(url: url, value: (nil, handler))
+      routes.insert(url, withValue: (nil, handler))
     }
 
     return true
@@ -71,7 +71,7 @@ class RouteManager {
   func searchController(url: URL) -> ([String: AnyObject], FRDIntentReceivable.Type?) {
     let params = extractParameters(url: url)
 
-    if let (clazz, _) = routes.searchWithNearestMatch(url: url) {
+    if let (clazz, _) = routes.searchNearestMatchedValue(with: url) {
       return (params, clazz)
     } else {
       return (params, nil)
@@ -89,7 +89,7 @@ class RouteManager {
   func searchHandler(url: URL) -> ([String: AnyObject], URLRoutesHandler?) {
     let params = extractParameters(url: url)
 
-    if let (_, handler) = routes.searchWithNearestMatch(url: url) {
+    if let (_, handler) = routes.searchNearestMatchedValue(with: url) {
       return (params, handler)
     } else {
       return (params, nil)
@@ -100,7 +100,7 @@ class RouteManager {
   private func extractParameters(url: URL) -> [String: AnyObject] {
 
     // Extract placeholder parameters
-    var params = routes.matchUrlPattern(url: url)
+    var params = routes.matchedPattern(for: url)
 
     // Add url to params
     params.updateValue(url as AnyObject, forKey: FRDRouteParameters.URLRouteURL)

--- a/FRDIntent/Source/Core/Trie.swift
+++ b/FRDIntent/Source/Core/Trie.swift
@@ -50,14 +50,14 @@ final class Trie<T> {
    - parameter url: the url.
    - parameter value: the value for inserting.
    */
-  func insert(url: URL, value: T) {
+  func insert(_ url: URL, withValue value: T) {
     guard let paths = url.pathComponentsWithoutSlash else {
       return
     }
-    insert(paths: paths, value: value)
+    insertPaths(paths, withValue: value)
   }
 
-  private func insert(paths: [String], value: T) {
+  private func insertPaths(_ paths: [String], withValue value: T) {
     guard !paths.isEmpty else {
       return
     }
@@ -67,7 +67,7 @@ final class Trie<T> {
       if let child = currentNode.children[path] {
         currentNode = child
       } else {
-        currentNode.addChild(key: path, value: value)
+        currentNode.addChild(withKey: path, value: value)
         currentNode = currentNode.children[path]!
       }
     }
@@ -81,14 +81,14 @@ final class Trie<T> {
 
    - returns: the node's value.
    */
-  func search(url: URL) -> T? {
+  func search(_ url: URL) -> T? {
     guard let paths = url.pathComponentsWithoutSlash else {
       return nil
     }
-    return search(paths: paths)
+    return searchPaths(paths)
   }
 
-  private func search(paths: [String]) -> T? {
+  private func searchPaths(_ paths: [String]) -> T? {
     guard !paths.isEmpty else {
       return nil
     }
@@ -98,7 +98,7 @@ final class Trie<T> {
       if let child = currentNode.children[path] {
         currentNode = child
       } else {
-        if let child = currentNode.childOrFirstPlaceholder(key: path) {
+        if let child = currentNode.childOrFirstPlaceholder(forKey: path) {
           currentNode = child
         } else {
           return nil
@@ -115,14 +115,14 @@ final class Trie<T> {
 
    - returns: the node's value. If trie has this paths, return the value in this node. If trie has not this paths, return the nearest registered url parent.
    */
-  func searchWithNearestMatch(url: URL) -> T? {
+  func searchNearestMatchedValue(with url: URL) -> T? {
     guard let paths = url.pathComponentsWithoutSlash else {
       return nil
     }
-    return searchWithNearestMatch(paths: paths)
+    return searchWNearestMatchValue(withPaths: paths)
   }
 
-  private func searchWithNearestMatch(paths: [String]) -> T? {
+  private func searchWNearestMatchValue(withPaths paths: [String]) -> T? {
     guard !paths.isEmpty else {
       return nil
     }
@@ -136,7 +136,7 @@ final class Trie<T> {
           nearestUrlParent = currentNode
         }
       } else {
-        if let child = currentNode.childOrFirstPlaceholder(key: path) {
+        if let child = currentNode.childOrFirstPlaceholder(forKey: path) {
           currentNode = child
           if currentNode.isTerminating {
             nearestUrlParent = currentNode
@@ -158,7 +158,7 @@ final class Trie<T> {
 
    - returns: dictionary for the pattern match result.
    */
-  func matchUrlPattern(url: URL) -> [String: AnyObject] {
+  func matchedPattern(for url: URL) -> [String: AnyObject] {
     guard let paths = url.pathComponentsWithoutSlash else {
       return [:]
     }
@@ -173,7 +173,7 @@ final class Trie<T> {
       if let child = currentNode.children[path] {
         currentNode = child
       } else {
-        if let child = currentNode.childOrFirstPlaceholder(key: path) {
+        if let child = currentNode.childOrFirstPlaceholder(forKey: path) {
           if child.isPlaceholder {
             params[child.placeholder!] = path as AnyObject
           }
@@ -210,7 +210,7 @@ final class TrieNode<T> {
     self.value = value
   }
 
-  func addChild(key: String, value: T) {
+  func addChild(withKey key: String, value: T) {
     guard children[key] == nil else {
       return
     }
@@ -233,7 +233,7 @@ extension TrieNode {
     return nil
   }
 
-  func childOrFirstPlaceholder(key: String) -> TrieNode? {
+  func childOrFirstPlaceholder(forKey key: String) -> TrieNode? {
     if let child = children[key] {
       return child
     } else {

--- a/FRDIntent/Source/Intent/FRDControllerDisplay.swift
+++ b/FRDIntent/Source/Intent/FRDControllerDisplay.swift
@@ -19,6 +19,6 @@ import UIKit
    - parameter source: The source view controller.
    - parameter destination: The destination view controller.
    */
-  func displayViewController(source: UIViewController, destination: UIViewController)
+  func displayViewController(from source: UIViewController, to destination: UIViewController)
 
 }

--- a/FRDIntent/Source/Intent/FRDControllerManager.swift
+++ b/FRDIntent/Source/Intent/FRDControllerManager.swift
@@ -26,7 +26,7 @@ public class FRDControllerManager: NSObject {
    
    - returns: True if it registers successfully.
    */
-  @discardableResult public func register(url: URL, clazz: AnyClass) -> Bool {
+  @discardableResult public func register(_ url: URL, clazz: AnyClass) -> Bool {
     return routeManager.register(url, clazz: clazz as! FRDIntentReceivable.Type)
   }
 
@@ -37,7 +37,7 @@ public class FRDControllerManager: NSObject {
    
    - returns: True if it registers successfully.
    */
-  public func registers(plistFile: String) -> Bool {
+  public func register(withPlistFile plistFile: String) -> Bool {
 
     guard let registers: NSDictionary = NSDictionary(contentsOfFile: plistFile) else {
       return false
@@ -50,7 +50,7 @@ public class FRDControllerManager: NSObject {
       }
 
       if let clazz = NSClassFromString(className) as? FRDIntentReceivable.Type {
-        let result = register(url: URL(string: url)!, clazz: clazz)
+        let result = register(URL(string: url)!, clazz: clazz)
         if !result {
           return false
         }
@@ -66,7 +66,7 @@ public class FRDControllerManager: NSObject {
    - parameter source: The source view controller.
    - parameter intent: The intent for launch a new view controller.
    */
-  public func startController(source: UIViewController, intent: FRDIntent) {
+  public func startController(from source: UIViewController, withIntent intent: FRDIntent) {
 
     var parameters = [String: AnyObject]()
     var controllerClazz: FRDIntentReceivable.Type?
@@ -116,7 +116,7 @@ public class FRDControllerManager: NSObject {
    - parameter intent: The intent for start new view controller.
    - parameter requestCode : this code will be returned in onControllerResult() when the view controller exits.
    */
-  public func startControllerForResult(source: UIViewController, intent: FRDIntent, requestCode: Int) {
+  public func startControllerForResult(from source: UIViewController, withIntent intent: FRDIntent, requestCode: Int) {
 
     typealias ControllerType = FRDIntentForResultReceivable.Type
 
@@ -176,8 +176,8 @@ public extension UIViewController {
 
    - parameter intent: The intent for launch a new view controller.
    */
-  func startController(intent: FRDIntent) {
-    FRDControllerManager.sharedInstance.startController(source: self, intent: intent)
+  func startController(withIntent intent: FRDIntent) {
+    FRDControllerManager.sharedInstance.startController(from: self, withIntent: intent)
   }
 
   /**
@@ -187,10 +187,10 @@ public extension UIViewController {
    - parameter pathIdentifier: The pathIdentifier for initializing the intent.
    - parameter extras: The datas for initializing the intent.
    */
-  func startController(pathIdentifier: String, extras: [String: AnyObject]) {
+  func startController(withPathIdentifier pathIdentifier: String, extras: [String: AnyObject]) {
     let intent = FRDIntent(pathIdentifier: pathIdentifier)
     intent.putExtraDatas(extras)
-    self.startController(intent: intent)
+    self.startController(withIntent: intent)
   }
 
   /**
@@ -201,8 +201,8 @@ public extension UIViewController {
    - parameter intent: The intent for start new view controller.
    - parameter requestCode : this code will be returned in onControllerResult() when the view controller exits.
    */
-  func startControllerForResult(intent: FRDIntent, requestCode: Int) {
-    FRDControllerManager.sharedInstance.startControllerForResult(source: self, intent: intent, requestCode: requestCode)
+  func startControllerForResult(withIntent intent: FRDIntent, requestCode: Int) {
+    FRDControllerManager.sharedInstance.startControllerForResult(from: self, withIntent: intent, requestCode: requestCode)
   }
 
   /**
@@ -214,10 +214,10 @@ public extension UIViewController {
    - parameter extras: The datas for initializing the intent.
    - parameter requestCode : this code will be returned in onControllerResult() when the view controller exits.
    */
-  func startControllerForResult(pathIdentifier: String, extras: [String: AnyObject], requestCode: Int) {
+  func startControllerForResult(withPathIdentifier pathIdentifier: String, extras: [String: AnyObject], requestCode: Int) {
     let intent = FRDIntent(pathIdentifier: pathIdentifier)
     intent.putExtraDatas(extras)
-    self.startControllerForResult(intent: intent, requestCode: requestCode)
+    self.startControllerForResult(withIntent: intent, requestCode: requestCode)
   }
 
   /**
@@ -225,7 +225,7 @@ public extension UIViewController {
 
    - parameter extras: The datas of intent received.
    */
-  func setup(extras: [String: AnyObject]) {
+  func setupExtras(_ extras: [String: AnyObject]) {
     if let title = extras[FRDIntentParameters.title] as? String {
       self.title = title
     }

--- a/FRDIntent/Source/Intent/FRDControllerManager.swift
+++ b/FRDIntent/Source/Intent/FRDControllerManager.swift
@@ -27,7 +27,7 @@ public class FRDControllerManager: NSObject {
    - returns: True if it registers successfully.
    */
   @discardableResult public func register(url: URL, clazz: AnyClass) -> Bool {
-    return routeManager.register(url: url, clazz: clazz as! FRDIntentReceivable.Type)
+    return routeManager.register(url, clazz: clazz as! FRDIntentReceivable.Type)
   }
 
   /**
@@ -72,7 +72,7 @@ public class FRDControllerManager: NSObject {
     var controllerClazz: FRDIntentReceivable.Type?
 
     if let url = intent.url {
-      let (params, clazz) = routeManager.searchController(url: url)
+      let (params, clazz) = routeManager.searchController(for: url)
       parameters = params
       controllerClazz = clazz
     }
@@ -124,7 +124,7 @@ public class FRDControllerManager: NSObject {
     var controllerClazz: ControllerType?
 
     if let url = intent.url {
-      let (params, clazz) = routeManager.searchController(url: url)
+      let (params, clazz) = routeManager.searchController(for: url)
       parameters = params
       controllerClazz = clazz as? ControllerType
     }

--- a/FRDIntent/Source/Intent/FRDControllerManager.swift
+++ b/FRDIntent/Source/Intent/FRDControllerManager.swift
@@ -83,7 +83,7 @@ public class FRDControllerManager: NSObject {
 
     if let controllerClazz = controllerClazz {
       for (key, value) in parameters {
-        intent.putExtra(name: key, data: value)
+        intent.putExtraName(key, withValue: value)
       }
 
       if let destination = InitializerHelper.viewController(fromClazz: controllerClazz, extras: intent.extras) as? FRDIntentReceivable {
@@ -136,7 +136,7 @@ public class FRDControllerManager: NSObject {
     if let controllerClazz = controllerClazz {
 
       for (key, value) in parameters {
-        intent.putExtra(name: key, data: value)
+        intent.putExtraName(key, withValue: value)
       }
 
       if let destination = InitializerHelper.viewController(fromClazz: controllerClazz, extras: intent.extras) as? FRDIntentForResultReceivable {
@@ -189,7 +189,7 @@ public extension UIViewController {
    */
   func startController(pathIdentifier: String, extras: [String: AnyObject]) {
     let intent = FRDIntent(pathIdentifier: pathIdentifier)
-    intent.putExtras(datas: extras)
+    intent.putExtraDatas(extras)
     self.startController(intent: intent)
   }
 
@@ -216,7 +216,7 @@ public extension UIViewController {
    */
   func startControllerForResult(pathIdentifier: String, extras: [String: AnyObject], requestCode: Int) {
     let intent = FRDIntent(pathIdentifier: pathIdentifier)
-    intent.putExtras(datas: extras)
+    intent.putExtraDatas(extras)
     self.startControllerForResult(intent: intent, requestCode: requestCode)
   }
 

--- a/FRDIntent/Source/Intent/FRDControllerManager.swift
+++ b/FRDIntent/Source/Intent/FRDControllerManager.swift
@@ -88,7 +88,7 @@ public class FRDControllerManager: NSObject {
 
       if let destination = InitializerHelper.viewController(fromClazz: controllerClazz, extras: intent.extras) as? FRDIntentReceivable {
 
-        if let validateResult = destination.validate?(intent: intent), validateResult == false {
+        if let validateResult = destination.validate?(intent), validateResult == false {
           return
         }
 
@@ -141,7 +141,7 @@ public class FRDControllerManager: NSObject {
 
       if let destination = InitializerHelper.viewController(fromClazz: controllerClazz, extras: intent.extras) as? FRDIntentForResultReceivable {
 
-        if let validateResult = destination.validate?(intent: intent), validateResult == false {
+        if let validateResult = destination.validate?(intent), validateResult == false {
           return
         }
 

--- a/FRDIntent/Source/Intent/FRDControllerManager.swift
+++ b/FRDIntent/Source/Intent/FRDControllerManager.swift
@@ -100,7 +100,7 @@ public class FRDControllerManager: NSObject {
         }
 
         if let destination = destination as? UIViewController {
-          display.displayViewController(source: source, destination: destination)
+          display.displayViewController(from: source, to: destination)
         }
       }
 
@@ -158,7 +158,7 @@ public class FRDControllerManager: NSObject {
         }
 
         if let destination = destination as? UIViewController {
-          display.displayViewController(source: source, destination: destination)
+          display.displayViewController(from: source, to: destination)
         }
       }
     }

--- a/FRDIntent/Source/Intent/FRDIntent.swift
+++ b/FRDIntent/Source/Intent/FRDIntent.swift
@@ -66,8 +66,8 @@ public class FRDIntent: NSObject {
    - parameter name: key
    - parameter data: value
   */
-  public func putExtra(name: String, data: AnyObject) {
-    self.extras[name] = data
+  public func putExtraName(_ name: String, withValue value: AnyObject) {
+    self.extras[name] = value
   }
 
   /**
@@ -75,7 +75,7 @@ public class FRDIntent: NSObject {
    
    - parameter data: the data dictionary.
    */
-  public func putExtras(datas: [String: AnyObject]) {
+  public func putExtraDatas(_ datas: [String: AnyObject]) {
     for (key, value) in datas {
       self.extras[key] = value
     }

--- a/FRDIntent/Source/Intent/FRDIntentReceivable.swift
+++ b/FRDIntent/Source/Intent/FRDIntentReceivable.swift
@@ -27,5 +27,5 @@ import Foundation
 
    - returns true open this view controller, flase will not this view controller.
    */
-  @objc optional func validate(intent: FRDIntent) -> Bool
+  @objc optional func validate(_ intent: FRDIntent) -> Bool
 }

--- a/FRDIntent/Source/Intent/FRDPresentationDisplay.swift
+++ b/FRDIntent/Source/Intent/FRDPresentationDisplay.swift
@@ -19,7 +19,7 @@ open class FRDPresentationDisplay: NSObject, FRDControllerDisplay {
    - parameter source: The source view controller.
    - parameter destination: The destination view controller.
    */
-  open func displayViewController(source: UIViewController, destination: UIViewController) {
+  open func displayViewController(from source: UIViewController, to destination: UIViewController) {
     let nav = UINavigationController(rootViewController: destination)
     source.present(nav, animated: true, completion: nil)
   }

--- a/FRDIntent/Source/Intent/FRDPushDisplay.swift
+++ b/FRDIntent/Source/Intent/FRDPushDisplay.swift
@@ -19,7 +19,7 @@ open class FRDPushDisplay: NSObject, FRDControllerDisplay {
    - parameter source: The source view controller.
    - parameter destination: The destination view controller.
    */
-  open func displayViewController(source: UIViewController, destination: UIViewController) {
+  open func displayViewController(from source: UIViewController, to destination: UIViewController) {
     if let navigationController = source.navigationController {
       navigationController.pushViewController(destination, animated: true)
     }

--- a/FRDIntent/Source/Intent/IntentForResult.swift
+++ b/FRDIntent/Source/Intent/IntentForResult.swift
@@ -34,7 +34,7 @@ import Foundation
    - parameter resultCode: The result code returned by the child conroller.
    - parameter intent: An Intent, which can return result data to the caller (various data can be attached to Intent "extras").
   */
-  func onControllerResult(requestCode: Int, resultCode: FRDResultCode, data: FRDIntent)
+  func controllerDidReture(withReqeustCode requestCode: Int, resultCode: FRDResultCode, data: FRDIntent)
 
 }
 

--- a/FRDIntent/Source/Intent/IntentForResult.swift
+++ b/FRDIntent/Source/Intent/IntentForResult.swift
@@ -34,7 +34,7 @@ import Foundation
    - parameter resultCode: The result code returned by the child conroller.
    - parameter intent: An Intent, which can return result data to the caller (various data can be attached to Intent "extras").
   */
-  func controllerDidReture(withReqeustCode requestCode: Int, resultCode: FRDResultCode, data: FRDIntent)
+  func controllerDidReturn(withReqeustCode requestCode: Int, resultCode: FRDResultCode, data: FRDIntent)
 
 }
 

--- a/FRDIntent/Source/URLRoutes/FRDURLRoutes.swift
+++ b/FRDIntent/Source/URLRoutes/FRDURLRoutes.swift
@@ -27,7 +27,7 @@ public class FRDURLRoutes: NSObject {
    - returns: True if it registers successfully.
    */
   @discardableResult public func register(url: URL, handler: @escaping URLRoutesHandler) -> Bool {
-    return routeManager.register(url: url, handler: handler)
+    return routeManager.register(url, handler: handler)
   }
 
   /**
@@ -38,7 +38,7 @@ public class FRDURLRoutes: NSObject {
    - returns: True if handler block is found and called, false if handler block is not found.
    */
   public func route(url: URL) -> Bool {
-    let (params ,handler) = routeManager.searchHandler(url: url)
+    let (params ,handler) = routeManager.searchHandler(for: url)
     if let handler = handler {
       handler(params)
       return true

--- a/FRDIntent/Source/URLRoutes/FRDURLRoutes.swift
+++ b/FRDIntent/Source/URLRoutes/FRDURLRoutes.swift
@@ -26,7 +26,7 @@ public class FRDURLRoutes: NSObject {
    
    - returns: True if it registers successfully.
    */
-  @discardableResult public func register(url: URL, handler: @escaping URLRoutesHandler) -> Bool {
+  @discardableResult public func register(_ url: URL, handler: @escaping URLRoutesHandler) -> Bool {
     return routeManager.register(url, handler: handler)
   }
 
@@ -37,7 +37,7 @@ public class FRDURLRoutes: NSObject {
 
    - returns: True if handler block is found and called, false if handler block is not found.
    */
-  public func route(url: URL) -> Bool {
+  public func route(_ url: URL) -> Bool {
     let (params ,handler) = routeManager.searchHandler(for: url)
     if let handler = handler {
       handler(params)
@@ -58,10 +58,10 @@ public extension FRDURLRoutes {
    
    - returns: True if it registers successfully.
    */
-  @discardableResult public func register(url: URL, clazz: FRDIntentReceivable.Type) -> Bool {
+  @discardableResult public func register(_ url: URL, clazz: FRDIntentReceivable.Type) -> Bool {
 
     let resultForIntent = FRDControllerManager.sharedInstance.register(url, clazz: clazz)
-    let resultForRoute = register(url: url) { (params: [String: AnyObject]) in
+    let resultForRoute = register(url) { (params: [String: AnyObject]) in
       let intent = FRDIntent(url: params[FRDRouteParameters.URLRouteURL] as! URL)
       if let topViewController = UIApplication.topViewController() {
         FRDControllerManager.sharedInstance.startController(from: topViewController, withIntent: intent)
@@ -78,7 +78,7 @@ public extension FRDURLRoutes {
 
    - returns: True if it registers successfully.
    */
-  public func registers(plistFile: String) -> Bool {
+  public func registerPlistFile(_ plistFile: String) -> Bool {
 
     guard let registers: NSDictionary = NSDictionary(contentsOfFile: plistFile) else {
       return false
@@ -91,7 +91,7 @@ public extension FRDURLRoutes {
       }
 
       if let clazz = NSClassFromString(className) as? FRDIntentReceivable.Type {
-        let result = register(url: URL(string: url)!, clazz: clazz)
+        let result = register(URL(string: url)!, clazz: clazz)
         if !result {
           return false
         }
@@ -105,18 +105,18 @@ public extension FRDURLRoutes {
 
 fileprivate extension UIApplication {
 
-  class func topViewController(base: UIViewController? = UIApplication.shared.keyWindow?.rootViewController) -> UIViewController? {
+  class func topViewController(from base: UIViewController? = UIApplication.shared.keyWindow?.rootViewController) -> UIViewController? {
 
     if let nav = base as? UINavigationController {
-      return topViewController(base: nav.visibleViewController)
+      return topViewController(from: nav.visibleViewController)
     }
     if let tab = base as? UITabBarController {
       if let selected = tab.selectedViewController {
-        return topViewController(base: selected)
+        return topViewController(from: selected)
       }
     }
     if let presented = base?.presentedViewController {
-      return topViewController(base: presented)
+      return topViewController(from: presented)
     }
     return base
 

--- a/FRDIntent/Source/URLRoutes/FRDURLRoutes.swift
+++ b/FRDIntent/Source/URLRoutes/FRDURLRoutes.swift
@@ -60,11 +60,11 @@ public extension FRDURLRoutes {
    */
   @discardableResult public func register(url: URL, clazz: FRDIntentReceivable.Type) -> Bool {
 
-    let resultForIntent = FRDControllerManager.sharedInstance.register(url: url, clazz: clazz)
+    let resultForIntent = FRDControllerManager.sharedInstance.register(url, clazz: clazz)
     let resultForRoute = register(url: url) { (params: [String: AnyObject]) in
       let intent = FRDIntent(url: params[FRDRouteParameters.URLRouteURL] as! URL)
       if let topViewController = UIApplication.topViewController() {
-        FRDControllerManager.sharedInstance.startController(source: topViewController, intent: intent)
+        FRDControllerManager.sharedInstance.startController(from: topViewController, withIntent: intent)
       }
     }
 

--- a/FRDIntentDemo/AppDelegate.m
+++ b/FRDIntentDemo/AppDelegate.m
@@ -65,12 +65,12 @@
 
 //iOS 9+
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options {
-  return [[FRDURLRoutes sharedInstance] routeWithUrl:url];
+  return [[FRDURLRoutes sharedInstance] route:url];
 }
 
 //iOS 8
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation{
-    return [[FRDURLRoutes sharedInstance] routeWithUrl:url];
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
+  return [[FRDURLRoutes sharedInstance] route:url];
 }
 
 - (void)configurationRoutes {
@@ -87,8 +87,8 @@
 
 
   // External call register
-  [[FRDURLRoutes sharedInstance] registerWithUrl:[NSURL URLWithString:@"/user/:userId/story/:storyId"]
-                                         handler:^(NSDictionary<NSString*, id> *params)
+  [[FRDURLRoutes sharedInstance] register:[NSURL URLWithString:@"/user/:userId/story/:storyId"]
+                                  handler:^(NSDictionary<NSString*, id> *params)
   {
     NSURL *url = [params objectForKey:FRDRouteParameters.URLRouteURL];
     FRDIntent *intent = [[FRDIntent alloc] initWithUrl:url];
@@ -106,7 +106,7 @@
 
   // External call register by plist
   NSString* routesPlistPath = [[NSBundle mainBundle] pathForResource:@"FRDURLRoutesRegisters" ofType:@"plist"];
-  [[FRDURLRoutes sharedInstance] registersWithPlistFile:routesPlistPath];
+  [[FRDURLRoutes sharedInstance] registerPlistFile:routesPlistPath];
 }
 
 @end

--- a/FRDIntentDemo/AppDelegate.m
+++ b/FRDIntentDemo/AppDelegate.m
@@ -82,7 +82,7 @@
 
   // Internal call register by plist
   NSString* plistPath = [[NSBundle mainBundle] pathForResource:@"FRDIntentRegisters" ofType:@"plist"];
-  [[FRDControllerManager sharedInstance] registersWithPlistFile:plistPath];
+  [[FRDControllerManager sharedInstance] registerWithPlistFile:plistPath];
 
 
 
@@ -95,7 +95,7 @@
     intent.controllerDisplay = [[FRDPresentationDisplay alloc] init];
     UIViewController *topViewController = [UIViewController topViewController];
     if (topViewController) {
-      [[FRDControllerManager sharedInstance] startControllerWithSource:topViewController intent:intent];
+      [[FRDControllerManager sharedInstance] startControllerFrom:topViewController withIntent:intent];
     }
   }];
 

--- a/FRDIntentDemo/FirstViewController.m
+++ b/FRDIntentDemo/FirstViewController.m
@@ -21,7 +21,7 @@
   self = [super init];
   if (self) {
     _data = extras;
-    [self setupWithExtras:extras];
+    [self setupExtras:extras];
   }
   return self;
 }

--- a/FRDIntentDemo/MainViewController.m
+++ b/FRDIntentDemo/MainViewController.m
@@ -12,7 +12,7 @@
 #import "ThirdViewController.h"
 #import "FourthViewController.h"
 
-@interface MainViewController () <FRDIntentForResultSendable>
+@interface MainViewController ()
 @end
 
 @implementation MainViewController

--- a/FRDIntentDemo/MainViewController.m
+++ b/FRDIntentDemo/MainViewController.m
@@ -69,7 +69,7 @@
 - (void)gotoSecondViewController
 {
   FRDIntent *intent = [[FRDIntent alloc] initWithClazz:[SecondViewController  class]];
-  [intent putExtraWithName:@"number" data: [NSNumber numberWithInteger:2]];
+  [intent putExtraName:@"number" withValue:[NSNumber numberWithInteger:2]];
   [self startControllerWithIntent:intent];
 }
 

--- a/FRDIntentDemo/ThirdViewController.m
+++ b/FRDIntentDemo/ThirdViewController.m
@@ -70,7 +70,7 @@
   if (self.delegate) {
     FRDIntent *intent = [[FRDIntent alloc] initWithUrl:[NSURL URLWithString:@"douban://"]];
     [intent putExtraName:@"text" withValue:self.textField.text];
-    [self.delegate controllerDidRetureWithReqeustCode:self.requestCode resultCode:FRDResultCodeCanceled data:intent];
+    [self.delegate controllerDidReturnWithReqeustCode:self.requestCode resultCode:FRDResultCodeCanceled data:intent];
   }
 }
 
@@ -79,7 +79,7 @@
   if (self.delegate) {
     FRDIntent *intent = [[FRDIntent alloc] initWithUrl:[NSURL URLWithString:@"douban://"]];
     [intent putExtraName:@"text" withValue:self.textField.text];
-    [self.delegate controllerDidRetureWithReqeustCode:self.requestCode resultCode:FRDResultCodeOk data:intent];
+    [self.delegate controllerDidReturnWithReqeustCode:self.requestCode resultCode:FRDResultCodeOk data:intent];
   }
 }
 

--- a/FRDIntentDemo/ThirdViewController.m
+++ b/FRDIntentDemo/ThirdViewController.m
@@ -69,7 +69,7 @@
 
   if (self.delegate) {
     FRDIntent *intent = [[FRDIntent alloc] initWithUrl:[NSURL URLWithString:@"douban://"]];
-    [intent putExtraWithName:@"text" data:self.textField.text];
+    [intent putExtraName:@"text" withValue:self.textField.text];
     [self.delegate onControllerResultWithRequestCode:self.requestCode resultCode:FRDResultCodeCanceled data:intent];
   }
 }
@@ -78,7 +78,7 @@
   [self dismissViewControllerAnimated:YES completion:NULL];
   if (self.delegate) {
     FRDIntent *intent = [[FRDIntent alloc] initWithUrl:[NSURL URLWithString:@"douban://"]];
-    [intent putExtraWithName:@"text" data:self.textField.text];
+    [intent putExtraName:@"text" withValue:self.textField.text];
     [self.delegate onControllerResultWithRequestCode:self.requestCode resultCode:FRDResultCodeOk data:intent];
   }
 }

--- a/FRDIntentDemo/ThirdViewController.m
+++ b/FRDIntentDemo/ThirdViewController.m
@@ -25,7 +25,7 @@
   self = [super init];
   if (self) {
     _data = extras;
-    [self setupWithExtras:extras];
+    [self setupExtras:extras];
   }
   return self;
 }

--- a/FRDIntentDemo/ThirdViewController.m
+++ b/FRDIntentDemo/ThirdViewController.m
@@ -70,7 +70,7 @@
   if (self.delegate) {
     FRDIntent *intent = [[FRDIntent alloc] initWithUrl:[NSURL URLWithString:@"douban://"]];
     [intent putExtraName:@"text" withValue:self.textField.text];
-    [self.delegate onControllerResultWithRequestCode:self.requestCode resultCode:FRDResultCodeCanceled data:intent];
+    [self.delegate controllerDidRetureWithReqeustCode:self.requestCode resultCode:FRDResultCodeCanceled data:intent];
   }
 }
 
@@ -79,7 +79,7 @@
   if (self.delegate) {
     FRDIntent *intent = [[FRDIntent alloc] initWithUrl:[NSURL URLWithString:@"douban://"]];
     [intent putExtraName:@"text" withValue:self.textField.text];
-    [self.delegate onControllerResultWithRequestCode:self.requestCode resultCode:FRDResultCodeOk data:intent];
+    [self.delegate controllerDidRetureWithReqeustCode:self.requestCode resultCode:FRDResultCodeOk data:intent];
   }
 }
 


### PR DESCRIPTION
@lincode 

除了 pr 中修改的，有几个剩下的但是觉得不太合理的没动：
1. 下面的 protocol 方法命名不太清楚
```
  /**
   When the result returns, this method will be called.
   
   - parameter requestCode: The integer request code originally supplied to startControllerForResult(), allowing you to identify who this result came from.
   - parameter resultCode: The result code returned by the child conroller.
   - parameter intent: An Intent, which can return result data to the caller (various data can be attached to Intent "extras").
  */
  func onControllerResult(requestCode: Int, resultCode: FRDResultCode, data: FRDIntent)
```

看起来这像是一个 delegate 方法，1 是命名上或者注释都会让阅读者比较困扰，单从命名或者注释并不能理解这个方法是做什么的、什么时候会调用 ；2 是 delegate 方法一般会带上 delegate 调用者本身，比如 `UIApplicationDelegate`  中的方法
```
func application(UIApplication, didDecodeRestorableStateWith: NSCoder)
```


2. 下面两个协议的命名有待商榷，首先名字就让人比较困惑...
`FRDIntentForResultSendable`
`FRDIntentForResultReceivable`

由于我对你的协议的设计思想不如你清晰，这几处你来看下吧。