### PR TITLE
Fix nearest node search bug

### DIFF
--- a/FRDIntent/Source/Core/RouteManager.swift
+++ b/FRDIntent/Source/Core/RouteManager.swift
@@ -123,7 +123,7 @@ class RouteManager {
   func searchController(with url: URL) -> ([String: Any], FRDIntentReceivable.Type?) {
     let params = extractParameters(from: url)
 
-    if let (clazz, _) = routes.searchNearestMatchedValue(with: url) {
+    if let (clazz, _) = routes.search(with: url) {
       return (params, clazz)
     } else {
       return (params, nil)
@@ -141,7 +141,7 @@ class RouteManager {
   func searchHandler(with url: URL) -> ([String: Any], URLRoutesHandler?) {
     let params = extractParameters(from: url)
 
-    if let (_, handler) = routes.searchNearestMatchedValue(with: url) {
+    if let (_, handler) = routes.search(with: url) {
       return (params, handler)
     } else {
       return (params, nil)

--- a/FRDIntent/Source/Core/RouteManager.swift
+++ b/FRDIntent/Source/Core/RouteManager.swift
@@ -86,6 +86,31 @@ class RouteManager {
     }
   }
 
+  /**
+   Check the url is registered or not.
+
+   - parameter url: The url to be checked.
+   */
+  func hasRegisteredController(with url: URL) -> Bool {
+    guard let node = routes.searchNodeWithtMatchPlaceholder(with: url) else { return false }
+    if let (clazz, _) = node.value {
+      if clazz == nil {
+        return false
+      }
+    }
+    return true
+  }
+
+  func hasRegisteredHandler(with url: URL) -> Bool {
+    guard let node = routes.searchNodeWithtMatchPlaceholder(with: url) else { return false }
+    if let (_, handler) = node.value {
+      if handler == nil {
+        return false
+      }
+    }
+    return true
+  }
+
   // MARK: - Search
 
   /**

--- a/FRDIntent/Source/Core/Trie.swift
+++ b/FRDIntent/Source/Core/Trie.swift
@@ -92,6 +92,7 @@ final class Trie<T> {
 
   /**
    This search method's behavior is different with classical trie's search.
+   When it can not find the node it will try to find the nearest parent node which is isTerminating.
 
    - parameter url: the url.
 
@@ -104,23 +105,51 @@ final class Trie<T> {
     }
     var currentNode = root
     var nearestUrlParent = root
+
     for path in paths {
       if let child = currentNode.childOrFirstPlaceholder(forKey: path) {
         currentNode = child
         if currentNode.isTerminating {
           nearestUrlParent = currentNode
         }
-      } else {
-        // not find
-        return nearestUrlParent.value
       }
-
     }
-    return currentNode.value
+
+    if currentNode.isTerminating {
+      return currentNode.value
+    } else {
+      return nearestUrlParent.value
+    }
+  }
+
+
+  /**
+   Find the node for given url, considering placeholder such as ":id".
+
+   - parameter url: the url.
+   - return the match node. Otherwise nil.
+   */
+  func searchNodeWithtMatchPlaceholder(with url: URL) -> TrieNode<T>? {
+    guard let paths = url.pathComponentsWithoutSlash, !paths.isEmpty else {
+      return nil
+    }
+
+    var currentNode = root
+    for path in paths {
+      if let child = currentNode.childOrFirstPlaceholder(forKey: path) {
+        currentNode = child
+      }
+    }
+
+    if currentNode.isTerminating {
+      return currentNode
+    }
+
+    return nil
   }
 
   /**
-   Find the node for given url
+   Find the node for given url without considering placeholder such as ":id".
 
    - parameter url: the url.
    - return the match node. Otherwise nil.
@@ -137,10 +166,11 @@ final class Trie<T> {
         return nil
       }
     }
-    if !currentNode.isTerminating {
-      return nil
+
+    if currentNode.isTerminating {
+      return currentNode
     }
-    return currentNode
+    return nil
   }
 
   /**

--- a/FRDIntent/Source/URLRoutes/FRDURLRoutes.swift
+++ b/FRDIntent/Source/URLRoutes/FRDURLRoutes.swift
@@ -54,8 +54,7 @@ public class FRDURLRoutes: NSObject {
    - returns: True if a handler can be found for the given url.
    */
   public func canRoute(_ url: URL) -> Bool {
-    let (_, handler) = routeManager.searchHandler(with: url)
-    return handler != nil
+    return routeManager.hasRegisteredHandler(with: url)
   }
 
   /**

--- a/FRDIntentTests/URLRoutesTests.swift
+++ b/FRDIntentTests/URLRoutesTests.swift
@@ -48,6 +48,24 @@ class URLRoutesTests: XCTestCase {
   }
 
 
+  func testPlaceholder() {
+
+    let router = FRDURLRoutes.sharedInstance
+
+    router.register(URL(string: "/a/x/c/d")!) { (params: [String: Any]) in
+      XCTAssert(params[FRDIntentParameters.URL] as? NSURL == NSURL(string:  "/a/x/c/d"), "")
+    }
+
+    router.register(URL(string: "/a/:b/c")!) { (params: [String: Any]) in
+      XCTAssert(params[FRDIntentParameters.URL] as? NSURL == NSURL(string:  "/a/x/c"), "")
+    }
+
+    let result = router.route(URL(string: "/a/x/c")!)
+    XCTAssert(result, "/a/x/c can route by pattern /a/:b/c")
+  }
+
+
+
   func testCanRoute() {
     let router = FRDURLRoutes.sharedInstance
 

--- a/FRDIntentTests/URLRoutesTests.swift
+++ b/FRDIntentTests/URLRoutesTests.swift
@@ -31,8 +31,26 @@ class URLRoutesTests: XCTestCase {
 
   }
 
+  func testNearestNoMatch() {
+
+    let router = FRDURLRoutes.sharedInstance
+
+    router.register(URL(string: "/a/b/c/e")!) { (params: [String: Any]) in
+      XCTAssert(params[FRDIntentParameters.URL] as? NSURL == NSURL(string:  "/a/b/c/e"), "")
+    }
+
+    router.register(URL(string: "/a/b")!) { (params: [String: Any]) in
+      XCTAssert(params[FRDIntentParameters.URL] as? NSURL == NSURL(string:  "/a/b/c"), "")
+    }
+
+    let result = router.route(URL(string: "/a/b/c")!)
+    XCTAssert(result, "can rout")
+  }
+
+
   func testCanRoute() {
     let router = FRDURLRoutes.sharedInstance
+
     router.register(URL(string: "/aaa/ddd")!) { (params) in
 
     }


### PR DESCRIPTION
@hao-feng 
- 修正了 canRoute 的含义，检查改为需要精确匹配。去掉了存在 nearest parent node 为真的这种情况。
- fix https://github.com/douban/FRDIntent/issues/48 中的两个 bug。